### PR TITLE
Implemented castling behavior for black and white

### DIFF
--- a/PieceController.java
+++ b/PieceController.java
@@ -1,0 +1,178 @@
+package gui.controllers;
+
+import bots.Bot;
+import bots.util.Move;
+import bots.util.Util;
+import core.pojo.Board;
+import gui.components.Block_Button;
+import gui.constants.MoveCounter;
+import gui.constants.PieceInfo;
+import gui.inGameScreen.BoardGui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Controls piece on board, getting selected piece and moves
+ */
+
+public record PieceController(Block_Button button, Board board, BoardGui boardGui,
+                              PieceInfo info, MoveCounter counter, Bot bot) implements ActionListener {
+
+
+    //@Checks if the value is negative or positive
+    public boolean getSide(byte i) {
+        boolean side = false;
+        if (i > 0) {
+            side = true;
+        }
+        return side;
+    }
+
+    public void resetValues() {
+        //returns original value in info
+        info.setHighlightedButton(new ArrayList<>());
+        info.setColorOfButtons(new ArrayList<>());
+    }
+
+    public void requestBotsMove() {
+        //gets bots move
+        Move move = bot.playNewMove(board.getGameBoard(), false, boardGui);
+
+        //gets icon of from move position
+
+        Icon icon2 = boardGui.getSquares()[move.fromCol()][move.fromRow()].getIcon();
+
+        board.updateBoard(Util.applyMove(board.getGameBoard(), move));
+        //updates move
+
+        //sets icon
+        boardGui.getSquares()[move.toCol()][move.toRow()].setIcon(icon2);
+        boardGui.getSquares()[move.fromCol()][move.fromRow()].setIcon(null);
+
+        // checks to see if the piece moved was a king, and if the move was a "castle"
+        if(board.getGameBoard()[move.toCol()][move.toRow()] == Math.abs(6) &&
+                                                Math.abs(move.fromCol() - move.toCol()) == 2){
+            int sign = -1;
+            // Queen side castle
+            if(move.toCol() == 2){
+                Icon icon1 = boardGui.getSquares()[0][move.fromRow()].getIcon();
+
+                boardGui.getSquares()[3][move.fromRow()].setIcon(icon1);
+                boardGui.getSquares()[0][move.fromRow()].setIcon(null);
+
+                board.setValue(3, move.fromRow(), (byte)(4*sign));
+                board.setValue(0, move.fromRow(), (byte)0);
+            // King side castle
+            } else if (move.toCol() == 6) {
+                Icon icon1 = boardGui.getSquares()[7][move.toRow()].getIcon();
+
+                boardGui.getSquares()[5][move.fromRow()].setIcon(icon1);
+                boardGui.getSquares()[7][move.fromRow()].setIcon(null);
+
+                board.setValue(5, move.fromRow(), (byte)(4*sign));
+                board.setValue(7, move.fromRow(), (byte)0);
+            }
+        }
+    }
+
+    public void highlightButtons(List<Move> possibleMoves) {
+        List<Block_Button> highlightedButtons = new ArrayList<>();
+        List<Color> colors = new ArrayList<>();
+
+        //check all the possible moves adds them to info.highlightedButtons and highlights them in color
+        /*to be able to revert them to original color we are also storing original colors in info.colors*/
+        for (int i = 0; i < possibleMoves.size(); i++) {
+            int row = possibleMoves.get(i).toRow();
+            int col = possibleMoves.get(i).toCol();
+            colors.add(boardGui.getSquares()[col][row].getBackground());
+            highlightedButtons.add(boardGui.getSquares()[col][row]);
+            boardGui.getSquares()[col][row].setBackground(Color.BLUE);
+        }
+
+        //then just sets the values to info's variables
+        info.setColorOfButtons(colors);
+        info.setHighlightedButton(highlightedButtons);
+    }
+
+    public void playMove() {
+        Icon icon = info.getSelectedButton().getIcon();//gets icon of selected button's piece
+        //gets the value in the gameBoard in board class and gets value of piece with buttons row and col values
+        byte piece = board.getGameBoard()[info.getSelectedButton().getCol()][info.getSelectedButton().getRow()];
+        //then it replaces the values in game board ,the position to move is set to 'piece'
+        board.setValue(button.getRow(), button.getCol(), piece);
+        //and the from position is set to 0
+        board.setValue(info.getSelectedButton().getRow(), info.getSelectedButton().getCol(), (byte) 0);
+        // Checks if the piece being moved is a king and if the move is a "castle"
+        if(piece == 6 && Math.abs(button.getRow() - info.getSelectedButton().getRow()) == 2){
+            Move newMove = new Move(info.getSelectedButton().getCol(), info.getSelectedButton().getRow(),
+                    button.getCol(), button.getRow(), (byte)0);
+            int sign = 1;
+
+            // Queen side castle
+            if(newMove.toCol() == 2){
+                Icon icon1 = boardGui.getSquares()[0][newMove.toRow()].getIcon();
+
+                boardGui.getSquares()[3][newMove.fromRow()].setIcon(icon1);
+                boardGui.getSquares()[0][newMove.fromRow()].setIcon(null);
+
+                board.setValue(3, newMove.fromRow(), (byte)(4*sign));
+                board.setValue(0, newMove.fromRow(), (byte)0);
+                // King side castle
+            } else if (newMove.toCol() == 6) {
+                Icon icon1 = boardGui.getSquares()[7][newMove.fromRow()].getIcon();
+
+                boardGui.getSquares()[5][newMove.fromRow()].setIcon(icon1);
+                boardGui.getSquares()[7][newMove.fromRow()].setIcon(null);
+
+                board.setValue(5, newMove.fromRow(), (byte)(4*sign));
+                board.setValue(7, newMove.fromRow(), (byte)0);
+            }
+        }
+        //it sets 'to position' button's icon to the 'from position' button's icon
+        button.setIcon(icon);
+        //it then sets 'from position' button's which is stored in 'info' icon to null
+        info.getSelectedButton().setIcon(null);
+        //since move has been played it reverts the variable values in info
+        info.setSelectedButton(null);
+        //returns color of highlighted buttons from blue to original color stored in info.Colors
+        for (int i = 0; i < info.getHighlightedButton().size(); i++) {
+            info.getHighlightedButton().get(i).setBackground(info.getColorOfButtons().get(i));
+        }
+    }
+
+    public void returnOriginalColor() {
+        //returns highlighted buttons background to original color from the color list in PieceInfo
+        for (int i = 0; i < info.getHighlightedButton().size(); i++) {
+            info.getHighlightedButton().get(i).setBackground(info.getColorOfButtons().get(i));
+        }
+    }
+
+    //true = black false = white
+    public void actionPerformed(ActionEvent event) {
+        //check if the button in grid's row and col value present in the board's game board is equal to players side
+        if (getSide(board.getGameBoard()[button().getCol()][button().getRow()]) == board.getSide() && counter().isTurn() == board().getSide() || info.containsObj(button)) {
+            if (info.getSelectedButton() == null) {
+                //if selected button in constants.info is null then it sets constant to the pressed button
+                List<Move> possibleMoves = Util.getPossibleMoves(board.getGameBoard(), button.getCol(), button().getRow());
+                info.setSelectedButton(button);
+                highlightButtons(possibleMoves);
+            } else if (info.getHighlightedButton().contains(button)) {
+                playMove();
+                resetValues();
+                counter.setTurn(!counter.isTurn());
+                requestBotsMove();
+                counter.setTurn(!counter.isTurn());
+            } else {
+                returnOriginalColor();
+                //sets all variables to null so that another button can be pressed
+                info.setSelectedButton(null);
+                resetValues();
+            }
+        }
+    }
+}

--- a/Util.java
+++ b/Util.java
@@ -1,0 +1,249 @@
+package bots.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Util {
+
+    private static boolean whiteQueenCastle = true;
+    private static boolean whiteKingCastle = true;
+    private static boolean blackQueenCastle = true;
+    private static boolean blackKingCastle = true;
+
+    private static boolean isValidPosition(int row, int col) {
+        return row >= 0 && row < 8 && col >= 0 && col < 8;
+    }
+
+    public static byte[][] deepCopy(byte[][] board) {
+        byte[][] newBoard = new byte[8][8];
+        for (int i = 0; i < 8; i++)
+            System.arraycopy(board[i], 0, newBoard[i], 0, 8);
+        return newBoard;
+    }
+
+    public static byte[][] applyMove(byte[][] board, Move move) {
+        byte[][] newBoard = Util.deepCopy(board);
+        int startRow = move.fromRow();
+        int startCol = move.fromCol();
+        int endRow = move.toRow();
+        int endCol = move.toCol();
+        newBoard[endRow][endCol] = newBoard[startRow][startCol];
+        newBoard[startRow][startCol] = 0;
+        return newBoard;
+    }
+
+    public static List<Move> getPossibleMoves(byte[][] board, int row, int col) {
+        List<Move> moves = new ArrayList<>();
+        byte piece = board[row][col];
+        int sign = (piece > 0) ? 1 : -1;
+
+        checkCastlingBools(board);
+
+        // Check all possible moves for the piece, based on its type
+        switch (Math.abs(piece)) {
+            case 1 -> moves.addAll(getPawnMoves(board, row, col, sign));
+            case 2 -> moves.addAll(getKnightMoves(board, row, col, sign));
+            case 3 -> moves.addAll(getBishopMoves(board, row, col, sign));
+            case 4 -> moves.addAll(getRockMoves(board, row, col, sign));
+            case 5 -> moves.addAll(getQueenMoves(board, row, col, sign));
+            case 6 -> moves.addAll(getKingMoves(board, row, col, sign));
+        }
+        return moves;
+    }
+
+    private static List<Move> getPawnMoves(byte[][] board, int row, int col, int sign) {
+        List<Move> moves = new ArrayList<>();
+
+        int start_location_black = 1;
+        int start_location_white = 6;
+
+        // Check one square forward
+        int newRow = row + (-1 * sign);
+        if (isValidPosition(newRow, col) && board[newRow][col] == 0)
+            moves.add(new Move(row, col, newRow, col, (byte) 0));
+
+        // Check two squares forward
+        newRow = row + (-2 * sign);
+        if (isValidPosition(newRow, col) && board[newRow][col] == 0 && board[newRow + sign][row] == 0) {
+            if (sign == -1 && row == start_location_black)
+                moves.add(new Move(row, col, newRow, col, (byte) 0));
+            else if (sign == 1 && row == start_location_white)
+                moves.add(new Move(row, col, newRow, col, (byte) 0));
+        }
+
+        // Check for capturing to the left
+        int newCol = col + (-1 * sign);
+        newRow = row + (-1 * sign);
+        if (isValidPosition(newRow, newCol)) {
+            byte target_piece = board[newRow][newCol];
+            if (target_piece != 0 && ((sign < 0 && target_piece > 0) || (sign > 0 && target_piece < 0)))
+                moves.add(new Move(row, col, newRow, newCol, (byte) Math.abs(target_piece)));
+        }
+
+        // Check for capturing to the right
+        newCol = col + (sign);
+        newRow = row + (-1 * sign);
+        if (isValidPosition(newRow, newCol)) {
+            byte target_piece = board[newRow][newCol];
+            if (target_piece != 0 && ((sign < 0 && target_piece > 0) || (sign > 0 && target_piece < 0)))
+                moves.add(new Move(row, col, newRow, newCol, (byte) Math.abs(target_piece)));
+        }
+        return moves;
+    }
+
+    private static List<Move> getKnightMoves(byte[][] board, int row, int col, int sign) {
+        List<Move> moves = new ArrayList<>();
+
+        int[][] Moves = {{2, -1}, {2, 1}, {1, 2}, {1, -2}, {-2, -1}, {-2, 1}, {-1, -2}, {-1, 2}};
+        for (int[] move : Moves) {
+            int newRow = row + (move[1] * sign);
+            int newCol = col + (move[0] * sign);
+
+            if (!isValidPosition(newRow, newCol)) continue;
+
+            int signOfEnemy = board[newRow][newCol] > 0 ? 1 : -1;
+            if (signOfEnemy != sign)
+                moves.add(new Move(row, col, newRow, newCol, board[newRow][newCol]));
+        }
+        return moves;
+    }
+
+    private static List<Move> getBishopMoves(byte[][] board, int row, int col, int sign) {
+        int[][] moves = {{1, 1}, {1, -1}, {-1, -1}, {-1, 1}};
+
+        return getLongMoves(board, row, col, sign, moves);
+    }
+
+    private static List<Move> getRockMoves(byte[][] board, int row, int col, int sign) {
+        int[][] moves = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+
+        return getLongMoves(board, row, col, sign, moves);
+    }
+
+    private static List<Move> getQueenMoves(byte[][] board, int row, int col, int sign) {
+        int[][] moves = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}, {1, 1}, {1, -1}, {-1, -1}, {-1, 1}};
+
+        return getLongMoves(board, row, col, sign, moves);
+    }
+
+    private static List<Move> getKingMoves(byte[][] board, int row, int col, int sign) {
+        List<Move> moves = new ArrayList<>();
+
+        int[][] Moves = {{1, 0}, {0, 1}, {-1, 0}, {0, -1}, {1, 1}, {1, -1}, {-1, -1}, {-1, 1}};
+        for (int[] move : Moves) {
+
+            int newRow = row + move[0];
+            int newCol = col + move[1];
+
+            if (isValidPosition(newRow, newCol)) {
+                if (board[newRow][newCol] == 0)
+                    moves.add(new Move(row, col, newRow, newCol, (byte) 0));
+                else if ((sign < 0 && board[newRow][newCol] > 0) || (sign > 0 && board[newRow][newCol] < 0))
+                    moves.add(new Move(row, col, newRow, newCol, board[newRow][newCol]));
+            }
+        }
+
+        //Black king and queen side castling check
+        if(sign == -1 && getBlackKingCastle()){
+            if(board[row][5] == 0 && board[row][6] == 0){
+                moves.add(new Move(row, col, row, 6, board[row][6]));
+            }
+        }
+
+        if(sign == -1 && getBlackQueenCastle()){
+            if(board[row][1] == 0 && board[row][2] == 0 && board[row][3] == 0){
+                moves.add(new Move(row, col, row, 2, board[row][2]));
+            }
+        }
+
+        //White king and queen side castling check
+        if(sign == 1 && getWhiteKingCastle()){
+            if(board[row][5] == 0 && board[row][6] == 0){
+                moves.add(new Move(row, col, row, 6, board[row][6]));
+            }
+        }
+
+        if(sign == 1 && getWhiteQueenCastle()){
+            if(board[row][1] == 0 && board[row][2] == 0 && board[row][3] == 0){
+                moves.add(new Move(row, col, row, 2, board[row][2]));
+            }
+        }
+
+
+        return moves;
+    }
+
+    private static List<Move> getLongMoves(byte[][] board, int row, int col, int sign, int[][] lines) {
+        List<Move> moves = new ArrayList<>();
+
+        for (int[] line : lines) {
+
+            int newRow = row + (line[1] * sign);
+            int newCol = col + (line[0] * sign);
+
+            while (isValidPosition(newRow, newCol)) {
+                if (board[newRow][newCol] == 0)
+                    moves.add(new Move(row, col, newRow, newCol, (byte) 0));
+                else if ((sign < 0 && board[newRow][newCol] > 0) || (sign > 0 && board[newRow][newCol] < 0)) {
+                    moves.add(new Move(row, col, newRow, newCol, (byte) 1));
+                    break;
+                } else break;
+                newRow += (line[1] * sign);
+                newCol += (line[0] * sign);
+            }
+        }
+        return moves;
+    }
+
+    public static boolean getWhiteQueenCastle() {return whiteQueenCastle;}
+
+    public static boolean getWhiteKingCastle() {return whiteKingCastle;}
+
+    public static boolean getBlackQueenCastle() {return blackQueenCastle;}
+
+    public static boolean getBlackKingCastle() {return blackKingCastle;}
+
+    public static void setWhiteQueenCastle(boolean value) {whiteQueenCastle = value;}
+
+    public static void setWhiteKingCastle(boolean value) {whiteKingCastle = value;}
+    public static void setBlackQueenCastle(boolean value) {blackQueenCastle = value;}
+
+    public static void setBlackKingCastle(boolean value) {blackKingCastle = value;}
+
+    private static void checkCastlingBools(byte[][] board){
+
+        int blackRow = 0;
+
+        if(board[blackRow][0] != -4){ setBlackQueenCastle(false);}
+        if(board[blackRow][7] != -4){ setBlackKingCastle(false);}
+
+        if(board[blackRow][4] != -6){
+            setBlackQueenCastle(false);
+            setBlackKingCastle(false);
+        }
+
+        int whiteRow = 7;
+
+        if(board[whiteRow][0] !=  4){ setWhiteQueenCastle(false);}
+        if(board[whiteRow][7] !=  4){ setWhiteKingCastle(false);}
+
+        if(board[whiteRow][4] !=  6){
+            setWhiteQueenCastle(false);
+            setWhiteKingCastle(false);
+        }
+
+    }
+
+    private static void checkCheckMate(int sign, byte[][] board) {
+        int rowKing;//row location of king
+        int colKing;//col location of king
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                if (board[i][j] == 6 * sign) {
+                    rowKing = i;
+                    colKing = j;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Edits made to both Util.java and PieceController.java files. Behavior allows players and AI to use both king and queen side castling.
Work includes:

**In Util**
- Adding variables to Util class to check for castling viability.
- Adding option to viable moves if all requirements are met for castling.
- Castling is initiated by attempting to move the king two spaces in the direction of a legal castle maneuver.

**in PieceController**
- Recognizing that either the player or the computer has initiated a legal castling maneuver.
- Moving the king the proper number of spaces, as well as moving the rook to the opposite adjacent square.
- Changes are properly reflected on both the board matrix and the GUI

Original Issue link: [here](https://github.com/MrMystery10-del/ChessEngine/issues/59)